### PR TITLE
Add credits for code sourced from fluffytw

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ This project is licenced under the MIT Licence with Attribution Requirement. See
 
 - [DDNet](https://github.com/ddnet/ddnet)
 - [Teeworlds](https://github.com/teeworlds/teeworlds)
+- [fluffytw](https://github.com/fluffysnaff/fluffytw)


### PR DESCRIPTION
This PR adds proper credits to the README for code that was sourced from [fluffytw](https://github.com/fluffysnaff/fluffytw). Specifically, functions like PredictHook and other aimbot-related features appear to be derived from that project.